### PR TITLE
Add UTF-safe explore

### DIFF
--- a/src/libs/Tiktoken/Encoding.cs
+++ b/src/libs/Tiktoken/Encoding.cs
@@ -52,6 +52,7 @@ public class Encoding
 
     private readonly CoreBpe _corePbe;
     private readonly HashSet<string> _specialTokensSet;
+    private static readonly HashSet<string> emptyHashSet = new HashSet<string>();
     
     /// <summary>
     /// Enable cache for fast encoding.
@@ -115,7 +116,24 @@ public class Encoding
         return _corePbe.Explore(
             text,
             allowedSpecial: _specialTokensSet,
-            disallowedSpecial: new HashSet<string>());
+            disallowedSpecial: emptyHashSet);
+    }
+    
+    /// <summary>
+    /// Returns tokens from the processing stage as a list of strings.
+    /// This would enhance visibility over the tokenization process, facilitate token manipulation,
+    /// and could serve as a useful tool for educational purposes.
+    /// Unlike <see cref="Explore"/> this method returns token in a printable manner, in which each token is encoded as one more tokens.
+    /// For example, <see cref="Encodings.Cl100KBase"/> can encode 🤚🏾 (Raised Back of Hand: Dark Skin Tone) with as much as 6 tokens.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    public IReadOnlyCollection<UtfToken> ExploreUtfSafe(string text)
+    {
+        return _corePbe.ExploreUtfSafe(
+            text,
+            allowedSpecial: _specialTokensSet,
+            disallowedSpecial: emptyHashSet);
     }
     
     /// <summary>
@@ -129,7 +147,7 @@ public class Encoding
         return _corePbe.EncodeNative(
             text,
             allowedSpecial: _specialTokensSet,
-            disallowedSpecial: new HashSet<string>());
+            disallowedSpecial: emptyHashSet);
     }
     
     /// <summary>
@@ -142,7 +160,7 @@ public class Encoding
     {
         return _corePbe.EncodeNative(
             text,
-            allowedSpecial: new HashSet<string>(),
+            allowedSpecial: emptyHashSet,
             disallowedSpecial: _specialTokensSet);
     }
     

--- a/src/libs/Tiktoken/UtfToken.cs
+++ b/src/libs/Tiktoken/UtfToken.cs
@@ -1,0 +1,13 @@
+namespace Tiktoken;
+
+public class UtfToken
+{
+    public string Token { get; private set; }
+    public int EncodedTokens { get; internal set; }
+    
+    public UtfToken(string token, int encodedTokens)
+    {
+        Token = token;
+        EncodedTokens = encodedTokens;
+    }
+}

--- a/src/libs/Tiktoken/Utilities/BytePairEncoding.cs
+++ b/src/libs/Tiktoken/Utilities/BytePairEncoding.cs
@@ -108,7 +108,7 @@ public static class BytePairEncoding
         return count;
     }
     
-    internal static unsafe IReadOnlyCollection<int> BytePairEncode(Bytes piece, IReadOnlyDictionary<byte[], int> ranks)
+    internal static unsafe List<int> BytePairEncode(Bytes piece, IReadOnlyDictionary<byte[], int> ranks)
     {
         var partsLength = piece.GetLength() + 1;
         var partsIndexes = stackalloc int [partsLength];
@@ -127,7 +127,7 @@ public static class BytePairEncoding
         return outList;
     }
     
-    internal static unsafe IReadOnlyCollection<byte[]> BytePairExplore(Bytes piece, IReadOnlyDictionary<byte[], int> ranks)
+    internal static unsafe List<byte[]> BytePairExplore(Bytes piece, IReadOnlyDictionary<byte[], int> ranks)
     {
         var partsLength = piece.GetLength() + 1;
         var partsIndexes = stackalloc int [partsLength];

--- a/src/tests/Tiktoken.UnitTests/Strings.cs
+++ b/src/tests/Tiktoken.UnitTests/Strings.cs
@@ -6,6 +6,7 @@ public static class Strings
     public const string Special = "hello <|endoftext|>";
     public const string Chinese = "我很抱歉，我不能提供任何非法或不道德的建议。快速赚钱是不容易的，需要耐心、刻苦努力和经验。如果您想增加收入，请考虑增加工作时间、寻找其他业务机会、学习新技能或提高自己的价值等方法。请记住，通过合法而道德的方式来获得收入，才是长期稳定的解决方案。";
     public const string KingLear = "King Lear, one of Shakespeare's darkest and most savage plays, tells the story of the foolish and Job-like Lear, who divides his kingdom, as he does his affections, according to vanity and whim. Lear’s failure as a father engulfs himself and his world in turmoil and tragedy.";
+    public const string EploreUtfBoundary = " řeknu";
     public const string Bitcoin = @"1. Introduction
 Commerce on the Internet has come to rely almost exclusively on financial institutions serving as
 trusted third parties to process electronic payments. While the system works well enough for

--- a/src/tests/Tiktoken.UnitTests/Tests.cs
+++ b/src/tests/Tiktoken.UnitTests/Tests.cs
@@ -118,4 +118,72 @@ public partial class Tests
         var newTest = new string(System.Text.Encoding.UTF8.GetBytes(test).Select(y => (char) y).ToArray());
         dictionaryNew.ContainsKey(newTest).Should().BeTrue();
     }
+    
+    [TestMethod]
+    public void ExploreUtfSafe()
+    {
+        var text = Strings.HelloWorld;
+        IReadOnlyCollection<string> tokens = Encoding.ForModel("gpt-4").Explore(text);
+        List<string> expected = new List<string> { "hello", " world" };
+        int i = 0;
+
+        tokens.Count.Should().Be(expected.Count);
+        
+        foreach (string token in tokens)
+        {
+            token.Should().Be(expected[i]);
+            i++;
+        }
+    }
+    
+    [TestMethod]
+    public void ExploreUtfBoundary()
+    {
+        var text = Strings.EploreUtfBoundary;
+        IReadOnlyCollection<UtfToken> tokens = Encoding.ForModel("gpt-4").ExploreUtfSafe(text);
+        List<string> expected = new List<string> { " ř", "ek", "nu" };
+        int i = 0;
+
+        tokens.Count.Should().Be(expected.Count);
+        
+        foreach (UtfToken token in tokens)
+        {
+            token.Token.Should().Be(expected[i]);
+            i++;
+        }
+    }
+    
+    [TestMethod]
+    public void ExploreUtfBoundaryEmojiSurrogate()
+    {
+        var text = "\ud83e\udd1a\ud83c\udffe";
+        IReadOnlyCollection<UtfToken> tokens = Encoding.ForModel("gpt-4").ExploreUtfSafe(text);
+        List<string> expected = new List<string> { "🤚🏾" };
+        int i = 0;
+
+        tokens.Count.Should().Be(expected.Count);
+        
+        foreach (UtfToken token in tokens)
+        {
+            token.Token.Should().Be(expected[i]);
+            i++;
+        }
+    }
+    
+    [TestMethod]
+    public void ExploreUtfBoundaryEmoji()
+    {
+        var text = "\ud83e\udd1ař";
+        IReadOnlyCollection<UtfToken> tokens = Encoding.ForModel("gpt-4").ExploreUtfSafe(text);
+        List<string> expected = new List<string> { "\ud83e\udd1a", "ř" };
+        int i = 0;
+
+        tokens.Count.Should().Be(expected.Count);
+        
+        foreach (UtfToken token in tokens)
+        {
+            token.Token.Should().Be(expected[i]);
+            i++;
+        }
+    }
 }


### PR DESCRIPTION
This implements the UTF-safe `Explore()` counterpart. The need for this was discussed in #2.