### PR TITLE
perf:reduce allocations in EncodingLoader

### DIFF
--- a/src/libs/Tiktoken.Core/CoreBPE.cs
+++ b/src/libs/Tiktoken.Core/CoreBPE.cs
@@ -45,7 +45,19 @@ public class CoreBpe
         Encoder = encoder;
         FastEncoder = Encoder
             .ToDictionary(
-                static x => new string(x.Key.Select(y => (char) y).ToArray()),
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+                static x =>
+                {
+                    Span<char> chars = stackalloc char[x.Key.Length];
+                    for (var i = 0; i < x.Key.Length; i++)
+                    {
+                        chars[i] = (char)x.Key[i];
+                    }
+                    return new string(chars);
+                },
+#else
+                static x => new string(x.Key.Select(static y => (char) y).ToArray()),
+#endif
                 static x => x.Value);
         SpecialTokensEncoder = specialTokensEncoder;
         


### PR DESCRIPTION
Improve performance of `ModelToEncoder.For("gpt-4o")` by reducing allocations:

- Avoid garbage strings from splitting on space.
- Avoid allocations from using LINQ in a hot loop.

```
BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5073/22H2/2022Update)
Intel Core i7-10875H CPU 2.30GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 9.0.100-rc.2.24474.11
  [Host] : .NET 9.0.0 (9.0.24.47305), X64 RyuJIT AVX2
  2.0.3  : .NET 9.0.0 (9.0.24.47305), X64 RyuJIT AVX2
  PR     : .NET 9.0.0 (9.0.24.47305), X64 RyuJIT AVX2
```

| Method     | Job   | NuGetReferences       | Mean     | Error    | StdDev   | Gen0      | Gen1      | Gen2     | Allocated | 
|----------- |------ |---------------------- |---------:|---------:|---------:|----------:|----------:|---------:|----------:| 
| GetEncoder | 2.0.3 | Tiktoken 2.0.3        | 83.67 ms | 3.943 ms | 5.901 ms | 3166.6667 | 1166.6667 | 166.6667 |   36.5 MB | 
| GetEncoder | PR    | This PR | 49.26 ms | 1.903 ms | 2.848 ms | 1090.9091 | 1000.0000 | 181.8182 |  19.53 MB | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced performance and memory efficiency for string processing and token handling, particularly for .NET 7.0 and greater.
	- Improved methods for loading and processing encodings, optimizing memory usage.

- **Bug Fixes**
	- Adjusted validation in the encoding loading process to ensure correct token counts.

- **Documentation**
	- Updated comments and formatting for clarity in the `EncodingLoader` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->