### PR TITLE
Add a proof of concept for using `GetAlternateLookup`

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
+    "version": "9.0.100-rc.2.24474.11",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/src/libs/Tiktoken.Core/Tiktoken.Core.csproj
+++ b/src/libs/Tiktoken.Core/Tiktoken.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net4.6.2;netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net4.6.2;netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <NoWarn>$(NoWarn);CA1724</NoWarn>
         <RootNamespace>Tiktoken</RootNamespace>


### PR DESCRIPTION
.NET 9 adds support for [collection lookups with spans](https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview6/libraries.md#collection-lookups-with-spans). This permits zero-allocation lookups in the `FastEncoder` dictionary using segments of an input string.

This PR is a proof-of-concept to start discussion about supporting this more fully when .NET 9 comes out. The performance gains are small, but the reduction in allocations from the lookups is significant. The downside is a significant increase in conditional compilation directives throughout the code.

```
BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5073/22H2/2022Update)
Intel Core i7-10875H CPU 2.30GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 9.0.100-rc.2.24474.11
  [Host] : .NET 9.0.0 (9.0.24.47305), X64 RyuJIT AVX2
  2.1.1  : .NET 9.0.0 (9.0.24.47305), X64 RyuJIT AVX2
  PR     : .NET 9.0.0 (9.0.24.47305), X64 RyuJIT AVX2
```

| Method      | Job   | NuGetReferences       | Mean     | Error     | StdDev    | Gen0   | Allocated |
|------------ |------ |---------------------- |---------:|----------:|----------:|-------:|----------:|
| CountTokens | 2.1.1 | Tiktoken 2.1.1        | 8.371 us | 0.2182 us | 0.3199 us | 0.2899 |    2552 B |
| CountTokens | PR    | This PR | 7.977 us | 0.0615 us | 0.0921 us |      - |      64 B |
